### PR TITLE
Code cleanup: add missing key and logic to avoid data race in PostcodeSearch

### DIFF
--- a/src/components/LocationFilter/index.js
+++ b/src/components/LocationFilter/index.js
@@ -12,8 +12,8 @@ function LocationFilter({ locations, selectedLocation, setSelectedLocation }) {
     <LocationFilterContainer>
       <strong>Filter by location</strong>
       {!!locations.length &&
-        locations.sort().map((location) => (
-          <LocationItem>
+        locations.sort().slice().map((location) => (
+          <LocationItem key={location}>
             <Block
               as={LocationLink}
               href="#"

--- a/src/components/PostcodeSearch/index.js
+++ b/src/components/PostcodeSearch/index.js
@@ -15,21 +15,27 @@ function PostcodeSearch({ setMapProps }) {
     if (!postcode || !postcode.match(POSTCODE_REGEX)) {
       return;
     }
+    let current = true;
     async function fetchPostCodeDetails(value) {
-      await fetch(`https://api.postcodes.io/postcodes/${value}`)
-        .then((response) => response.json())
-        .then(async (data) => {
-          if (data.status === 200) {
-            const { latitude, longitude } = data.result;
-            setMapProps({ coords: [latitude, longitude], zoom: 12 });
-            setError(false);
-          } else {
-            setError(true);
-          }
-        });
+      const data = await (await fetch(`https://api.postcodes.io/postcodes/${value}`)).json();
+      if (!current) {
+        // The requested props have changed, so this is no longer
+        // the most recent request. Do not update the map state.
+        return;
+      }
+      if (data.status === 200) {
+        const { latitude, longitude } = data.result;
+        setMapProps({ coords: [latitude, longitude], zoom: 12 });
+        setError(false);
+      } else {
+        setError(true);
+      }
     }
     fetchPostCodeDetails(postcode);
-  }, [postcode, setMapProps]);
+    return () => {
+      current = false;
+    };
+  }, [postcode, setMapProps, setError]);
 
   return (
     <>

--- a/src/components/PostcodeSearch/index.js
+++ b/src/components/PostcodeSearch/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import styled from "styled-components";
 
 const POSTCODE_REGEX = /^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$/;
@@ -11,6 +11,12 @@ function PostcodeSearch({ setMapProps }) {
     setPostcode(e.currentTarget.value);
   };
 
+
+
+  const currentSetMapProps = useRef(setMapProps);
+  useEffect(() => {
+    currentSetMapProps.current = setMapProps;
+  });
   useEffect(() => {
     if (!postcode || !postcode.match(POSTCODE_REGEX)) {
       return;
@@ -25,7 +31,7 @@ function PostcodeSearch({ setMapProps }) {
       }
       if (data.status === 200) {
         const { latitude, longitude } = data.result;
-        setMapProps({ coords: [latitude, longitude], zoom: 12 });
+        currentSetMapProps.current({ coords: [latitude, longitude], zoom: 12 });
         setError(false);
       } else {
         setError(true);
@@ -35,7 +41,7 @@ function PostcodeSearch({ setMapProps }) {
     return () => {
       current = false;
     };
-  }, [postcode, setMapProps, setError]);
+  }, [postcode, currentSetMapProps, setError]);
 
   return (
     <>


### PR DESCRIPTION
In `<LocationFilter />`, the `<LocationItem>` component was missing its `key`. Also, since `.sort()` mutates its list, I added `.slice()` beforehand to avoid unintentionally mutating the `locations` argument.

Separately, in `<PostcodeSearch />`, extra logic is added to avoid a data race in the `async` function called in `useEffect`. Specifically, if the user has a slow connection and changes the postcode quickly, then the requests might resolve out-of-order, causing an earlier request to overwrite a later one. To prevent this, we can track whether the current request is _still_ current by adding a `current` local variable, and updating it in the returned "cleanup" callback. This transformation could probably be applied more productively elsewhere, but I haven't investigated the rest of the codebase yet.