### PR TITLE
Provider useEffect loop

### DIFF
--- a/src/containers/provider.js
+++ b/src/containers/provider.js
@@ -10,9 +10,12 @@ const Provider = ({ match }) => {
   const { setSelectedIndex } = React.useContext(AppContext);
   const selectedIndex = match.params.id;
 
+  // setSelectedIndex isnt' a stable function so
+  // including it in the deps will cause an infinite loop
   useEffect(() => {
     setSelectedIndex(selectedIndex);
-  }, [setSelectedIndex]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedIndex]);
 
   return (
     <ProviderContainer>


### PR DESCRIPTION
Provider had a useEffect dependency on an unstable useState setter (and probably was buggy as it should have been listening to the selectedIndex it was setting instead).

Long term make that setter stable and add it to the deps but for now replace it with selectedIndex as the dep and ignore the exhaustive deps warning