### PR TITLE
connect up the /provider/id route to show the selected pane on load, and handle closing the pane

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,6 @@ function App() {
   const [selectedLocation, setSelectedLocation] = useState("All");
 
   useEffect(() => {
-    setSelectedIndex(null);
     setFetchingData(true);
 
     let url = `/.netlify/functions/providers?location=${selectedLocation}`;

--- a/src/components/SelectedPane/index.js
+++ b/src/components/SelectedPane/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Map, TileLayer } from "react-leaflet";
+import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
 import { AppContext } from "components/AppContext/AppContext";
@@ -20,6 +21,7 @@ import {
 } from "../../constants";
 
 function SelectedPane() {
+  const history = useHistory();
   const { data, selectedIndex, setSelectedIndex } = React.useContext(
     AppContext
   );
@@ -30,10 +32,15 @@ function SelectedPane() {
     return null;
   }
 
+  const handleCloseClick = () => {
+    setSelectedIndex(null);
+    history.push(`/`);
+  };
+
   return (
     <SelectedPaneContainer isMapMode={mode === "map"}>
       <small>
-        <CloseButton onClick={() => setSelectedIndex(null)}>Close</CloseButton>
+        <CloseButton onClick={handleCloseClick}>Close</CloseButton>
       </small>
       {/* <div style={{ height: "50%", width: "100%" }}>
         {[


### PR DESCRIPTION
when hitting /provider/1, the page wouldn't show the selected provider pane. This was because the data reload was wiping the selected state, so I removed that - if this an issue, let me know. Also added the close button functionality to go back to the main screen.