### PR TITLE
ensure selectedIndex isn't null before converting to a number

### DIFF
--- a/src/components/AppContext/AppContext.js
+++ b/src/components/AppContext/AppContext.js
@@ -54,7 +54,7 @@ const AppContextProvider = (props) => {
   function setSelectedIndex(selectedIndex) {
     dispatch({
       type: "SET_SELECTED_INDEX",
-      payload: Number(selectedIndex),
+      payload: selectedIndex != null ? Number(selectedIndex) : null,
     });
   }
 


### PR DESCRIPTION
setSelectedIndex was converting the payload to a number, but if `selectedIndex` was `null` was it was converting to `0`, causing the  first item to get selected whenever the SelectedPane was closed.