### PR TITLE
include more detailed results info

### DIFF
--- a/src/components/AppContext/AppContext.js
+++ b/src/components/AppContext/AppContext.js
@@ -39,6 +39,12 @@ const reducer = (state, action) => {
         filteredData: action.payload,
       }
 
+    case "SET_SELECTED_POSTCODE":
+      return {
+        ...state,
+        selectedPostcode: action.payload,
+      }
+
     default:
       return { ...state };
   }
@@ -51,6 +57,7 @@ const initialState = {
   locations: null,
   selectedIndex: null,
   selectedLocation: 'All',
+  selectedPostcode: null,
 };
 
 export const AppContext = React.createContext(initialState);
@@ -100,6 +107,13 @@ const AppContextProvider = (props) => {
     })
   }
 
+  function setSelectedPostcode(postcode) {
+    dispatch({
+      type: "SET_SELECTED_POSTCODE",
+      payload: postcode
+    })
+  }
+
   return (
     <AppContext.Provider
       value={{
@@ -109,12 +123,14 @@ const AppContextProvider = (props) => {
         locations: state.locations,
         selectedIndex: state.selectedIndex,
         selectedLocation: state.selectedLocation,
+        selectedPostcode: state.selectedPostcode,
         setData,
         setFetchingData,
         setFilteredData,
         setLocations,
         setSelectedIndex,
         setSelectedLocation,
+        setSelectedPostcode,
       }}
     >
       {props.children}

--- a/src/components/PostcodeSearch/index.js
+++ b/src/components/PostcodeSearch/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef, useContext } from "react";
 import styled from "styled-components";
 import { GeoContext } from "../GeoProvider";
 import { ReactComponent as IconLocation } from '../../images/icon-location.svg'
+import { AppContext } from "../AppContext/AppContext";
 
 const POSTCODE_REGEX = /^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$/;
 
@@ -9,6 +10,7 @@ function PostcodeSearch() {
   const [postcode, setPostcode] = useState("");
   const [error, setError] = useState(false);
   const { setMode, mode } = useContext(GeoContext);
+  const { setSelectedPostcode } = useContext(AppContext);
 
   const currentSetMapProps = useRef(setMode);
   useEffect(() => {
@@ -25,7 +27,10 @@ function PostcodeSearch() {
 
   useEffect(() => {
     if (!postcode || !postcode.match(POSTCODE_REGEX)) {
+      setSelectedPostcode(null);
       return;
+    } else {
+      setSelectedPostcode(postcode);
     }
     let current = true;
     async function fetchPostCodeDetails(value) {

--- a/src/components/PostcodeSearch/index.js
+++ b/src/components/PostcodeSearch/index.js
@@ -27,7 +27,6 @@ function PostcodeSearch() {
 
   useEffect(() => {
     if (!postcode || !postcode.match(POSTCODE_REGEX)) {
-      setSelectedPostcode(null);
       return;
     } else {
       setSelectedPostcode(postcode);

--- a/src/components/PostcodeSearch/index.js
+++ b/src/components/PostcodeSearch/index.js
@@ -57,7 +57,7 @@ function PostcodeSearch() {
     return () => {
       current = false;
     };
-  }, [postcode, currentSetMapProps, setError]);
+  }, [postcode, currentSetMapProps, setError, setSelectedPostcode]);
 
   return (
     <>

--- a/src/components/PostcodeSearch/index.js
+++ b/src/components/PostcodeSearch/index.js
@@ -57,7 +57,8 @@ function PostcodeSearch() {
     return () => {
       current = false;
     };
-  }, [postcode, currentSetMapProps, setError, setSelectedPostcode]);
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [postcode, currentSetMapProps, setError]);
 
   return (
     <>

--- a/src/components/ProviderList/index.js
+++ b/src/components/ProviderList/index.js
@@ -2,7 +2,6 @@ import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 import { AppContext } from "components/AppContext/AppContext";
-import { GeoContext } from "components/GeoProvider";
 import { NAME, BREAKPOINTS } from "../../constants";
 import { buildAddressString } from "utils/buildAddressString";
 
@@ -10,12 +9,13 @@ import Spinner from "../Spinner";
 
 function ProviderList() {
   const history = useHistory();
-  const { mode } = useContext(GeoContext);
   const {
     data,
     filteredData,
     selectedIndex,
     setSelectedIndex,
+    selectedLocation,
+    selectedPostcode,
   } = useContext(AppContext);
 
 
@@ -25,13 +25,16 @@ function ProviderList() {
   };
 
   const resultsLabel = () => {
-    switch (mode) {
-      case "geo":
-      case "postcode":
-        return "closest to you";
-      default:
-        return "across the country";
+    if (selectedPostcode !== null || selectedLocation !== "All") {
+      return `closest to ${selectedPostcode || selectedLocation}`
     }
+    if (selectedLocation === "All") {
+      return `across the country`
+    }
+    // never reaches this case, as selectedLocation must either be All OR a specific location.
+    // if (mode === "geo") {
+    //   return `closest to you`
+    // }
   };
 
   const providerData = filteredData !== null ? filteredData : data;  
@@ -41,7 +44,7 @@ function ProviderList() {
       {!!providerData ? (
         <>
           <p>
-            Showing {providerData.length} venues {resultsLabel()}
+            Showing {providerData.length} venue{providerData.length > 1 ? 's' : null} {resultsLabel()}
           </p>
           <div>
             {providerData.map((provider, i) => (

--- a/src/components/ProviderList/index.js
+++ b/src/components/ProviderList/index.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { AppContext } from "components/AppContext/AppContext";
 import { NAME, BREAKPOINTS } from "../../constants";
 import { buildAddressString } from "utils/buildAddressString";
+import { GeoContext } from "../GeoProvider/index";
 
 import Spinner from "../Spinner";
 
@@ -17,6 +18,7 @@ function ProviderList() {
     selectedLocation,
     selectedPostcode,
   } = useContext(AppContext);
+  const { mode } = useContext(GeoContext);
 
 
   const handleProviderClick = (i) => {
@@ -25,16 +27,14 @@ function ProviderList() {
   };
 
   const resultsLabel = () => {
-    if (selectedPostcode !== null || selectedLocation !== "All") {
-      return `closest to ${selectedPostcode || selectedLocation}`
+    switch (mode) {
+      case "geo":
+         return "closest to you";
+      case "postcode":	
+         return `closest to ${selectedPostcode}`
+      default:	
+        return selectedLocation === "All" ? "across the country" : `closest to ${selectedLocation}`;	
     }
-    if (selectedLocation === "All") {
-      return `across the country`
-    }
-    // never reaches this case, as selectedLocation must either be All OR a specific location.
-    // if (mode === "geo") {
-    //   return `closest to you`
-    // }
   };
 
   const providerData = filteredData !== null ? filteredData : data;  


### PR DESCRIPTION
I'm not sure it's possible to have all of the detailed messages, I found that adding more detailed results for

- All providers `across the country`
- Specific Location `closest to ${selectedLocation}`
- Valid Postcode Search `closest to ${selectedPostcode}`

Meant that one of these conditions would always be met, invalidating

- Geo `closest to you`

I believe it's down to preference which one you want to overwrite the others with. I've opted to omit the Geo case.

Let me know your thoughts.
 