### PR TITLE
rendering issues in VendorContainer fixed

### DIFF
--- a/src/components/ProviderList/index.js
+++ b/src/components/ProviderList/index.js
@@ -110,7 +110,7 @@ const VendorContainer = styled.li`
   display: grid;
   grid-gap: 30px;
   grid-template-columns: 1fr 24px;
-  height: 100px;
+  min-height: 100px;
   margin-bottom: 10px;
   padding: 10px 20px;
 


### PR DESCRIPTION
The set height was causing issues with certain vendors due to long titles

Before:
![image](https://user-images.githubusercontent.com/5125097/97255899-c02efb00-1865-11eb-9e87-3e326a9ef536.png)

After:
![image](https://user-images.githubusercontent.com/5125097/97255928-d50b8e80-1865-11eb-9327-3350144745ec.png)
