### PR TITLE
fix app crash on location change

### DIFF
--- a/src/components/LocationFilter/index.js
+++ b/src/components/LocationFilter/index.js
@@ -3,14 +3,17 @@ import styled from "styled-components";
 import { AppContext } from "../AppContext/AppContext";
 import IconSelected from "../../images/icon-selected.svg";
 import { BREAKPOINTS } from "../../constants";
+import { useHistory } from "react-router-dom";
 
 function LocationFilter() {
+  const history = useHistory();
   const {
     data,
     locations,
     setSelectedLocation,
     selectedLocation,
     setFilteredData,
+    setSelectedIndex,
   } = useContext(AppContext);
 
   const filterDataByLocation = (location) => {
@@ -18,8 +21,10 @@ function LocationFilter() {
   }
 
   const handleLocationClick = (e, location) => {
+    history.push(`/`);
     e.preventDefault();
     setSelectedLocation(location);
+    setSelectedIndex(null)
     if (location === "All") {
       setFilteredData(null)
     } else {


### PR DESCRIPTION
Currently, if you click provider{_n_} in all venues and then filter to a location that doesn't have at least _n_ venues, the route remains and crashes the app.